### PR TITLE
Systemd boot speed ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,11 @@ devel/
 src/CMakeLists.txt
 
 .bash_history
+
+# models
+*.pkl
 *.pt
+*.torchscript
 
 **/wandb/*
 .OutlineViewer/

--- a/docker/systemd/tj2_ros.service
+++ b/docker/systemd/tj2_ros.service
@@ -1,5 +1,5 @@
 [Unit]
-After=NetworkManager.service time-sync.target
+After=basic.target
 Description=TJ2 ROS
 
 [Service]


### PR DESCRIPTION
Also ignoring model files to save on git LFS space since we're on the free plan

To apply this change,
- upload code
- login into the Jetson
- Run the following
  - cd ~/tj2_ros/docker/systemd
  - `sudo install_systemd.sh`

These instructions have been added to the wiki but also run this command to disable the desktop:
`sudo systemctl set-default multi-user.target`